### PR TITLE
fix: pass gas limit to ethrex if network `gas_limit` was specified

### DIFF
--- a/src/el/ethrex/ethrex_launcher.star
+++ b/src/el/ethrex/ethrex_launcher.star
@@ -183,6 +183,9 @@ def get_config(
             )
         )
 
+    if network_params.gas_limit > 0:
+        cmd.append("--block-producer.gas-limit={0}".format(network_params.gas_limit))
+
     if len(participant.el_extra_params) > 0:
         # this is a repeated<proto type>, we convert it into Starlark
         cmd.extend([param for param in participant.el_extra_params])


### PR DESCRIPTION
This PR sets the target gas limit flag in ethrex if the `network_params.gas_limit` parameter is specified in ethereum-package.

Note: it depends on https://github.com/lambdaclass/ethrex/pull/4973